### PR TITLE
(WIP) Integrate check testframework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 *.i*86
 *.x86_64
 *.hex
+run-specs
 
 # Debug files
 *.dSYM/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 *.dSYM/
 
 doc
+tags

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,15 @@ PROJECT = smxrts
 LOC_INC_DIR = include
 LOC_SRC_DIR = src
 LOC_LIB_DIR = lib
+LOC_SPEC_DIR = specs
+
+SPEC_EXE_NAME = run-specs
 
 STATLIB = $(LOC_LIB_DIR)/lib$(PROJECT).a
 
 SOURCES = $(wildcard $(LOC_SRC_DIR)/*.c)
+
+SPECS = $(wildcard $(LOC_SPEC_DIR)/*.c)
 
 OBJECTS = $(SOURCES:%.c=%.o)
 
@@ -23,6 +28,8 @@ CFLAGS = -Wall -c
 DEBUG_FLAGS = -g -O0
 
 CC = gcc
+
+## Process this file with automake to produce Makefile.in
 
 all: $(STATLIB)
 
@@ -49,7 +56,10 @@ install:
 clean:
 	rm -f $(LOC_SRC_DIR)/$(PROJECT).o
 	rm -f $(LOC_LIB_DIR)/lib$(PROJECT).a
+	rm -f ./${SPEC_EXE_NAME}
 
 doc:
 	doxygen .doxygen
 
+spec: $(SPECS)
+	$(CC) $(SPECS) -Wall -o $(SPEC_EXE_NAME) -lcheck -pthread -lcheck_pic -pthread -lrt -lm -lsubunit

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Runtime system for the coordination language Streamix
 Requires
  - [`zlog`](https://github.com/HardySimpson/zlog)
  - [`pthread`](https://computing.llnl.gov/tutorials/pthreads/)
+ - [`check`](https://libcheck.github.io/check/web/install.html)
 
 ## Examples
 In the folder `examples` choose an example and run

--- a/specs/test.c
+++ b/specs/test.c
@@ -1,0 +1,22 @@
+#include <check.h>
+
+START_TEST(sanity_check) {
+  fail_unless(5 == 5, "this should succeed");
+}
+END_TEST
+
+int main(void) {
+  Suite *s1 = suite_create("Core");
+  TCase *tc1_1 = tcase_create("Core");
+  SRunner *sr = srunner_create(s1);
+  int nf;
+
+  suite_add_tcase(s1, tc1_1);
+  tcase_add_test(tc1_1, sanity_check);
+
+  srunner_run_all(sr, CK_ENV);
+  nf = srunner_ntests_failed(sr);
+  srunner_free(sr);
+
+  return nf == 0 ? 0 : 1;
+}


### PR DESCRIPTION
@moiri 

The purpose of this patch is to integrate a unit testing framework to prevent regression. 

Based on this stackoverflow post: https://stackoverflow.com/questions/65820/unit-testing-c-code I tried various test-frameworks and so far, check seems to be a promising one. Details can be found on their homepage: https://libcheck.github.io/check/web/install.html

I'm rather new to C and therefore would appreciate some feedback.